### PR TITLE
Hide points label in eventcarditem and hide guest from regular user

### DIFF
--- a/frontend/src/components/events/EventCardItem.jsx
+++ b/frontend/src/components/events/EventCardItem.jsx
@@ -5,6 +5,7 @@ import Card from '../common/Card';
 import Button from '../common/Button';
 import Badge from '../common/Badge';
 import theme from '../../styles/theme';
+import { useAuth } from '../../contexts/AuthContext';
 import { 
   FaEdit, 
   FaTrash, 
@@ -115,6 +116,7 @@ const ColoredBadge = styled(Badge)`
 const EventCardItem = ({ 
   event, 
   isManager, 
+  activeRole,
   formatCompactDate, 
   formatTime, 
   getEventCardDate, 
@@ -122,13 +124,16 @@ const EventCardItem = ({
   isRsvpd, 
   handleEditEvent, 
   handleDeleteEventClick, 
-  handleRsvpClick 
+  handleRsvpClick
 }) => {
   if (!event) return null; // Skip null/undefined events
-  
+  console.log('event.isOrganizer =', event?.isOrganizer);
   const { month, day } = getEventCardDate(event.startTime);
   const eventStatus = getEventStatus(event.startTime, event.endTime);
   const isUserRsvpd = isRsvpd(event);
+  const isRegularAndNotOrganizer = activeRole === 'regular' && !event.isOrganizer;
+
+
   
   return (
     <EventCard>
@@ -195,10 +200,14 @@ const EventCardItem = ({
           </EventDetail>
           
           
-          <EventDetail>
-            <FaCoins />
-            <span>{event.pointsRemain ?? 0} points available</span>
-          </EventDetail>
+          {!isRegularAndNotOrganizer && (
+       <EventDetail>
+        <FaCoins />
+       <span>{event.pointsRemain ?? 0} points available</span>
+      </EventDetail>
+)}
+
+
         </EventDetails>
         
         <EventActions>

--- a/frontend/src/components/events/EventList.jsx
+++ b/frontend/src/components/events/EventList.jsx
@@ -6,6 +6,10 @@ import { FaInfoCircle } from 'react-icons/fa';
 import theme from '../../styles/theme';
 import EventCardItem from './EventCardItem';
 import LoadingSpinner from '../common/LoadingSpinner';
+import { useAuth } from '../../contexts/AuthContext'; 
+
+
+
 
 const EventsContainer = styled.div`
   margin-bottom: ${theme.spacing.xl};
@@ -127,6 +131,8 @@ const EventList = ({
   handleDeleteEventClick,
   handleRsvpClick
 }) => {
+  const { user, activeRole } = useAuth();
+
   if (isLoading) {
     return <LoadingSpinner text="Loading events..." />;
   }
@@ -153,22 +159,28 @@ const EventList = ({
         animate="visible"
       >
         <EventsGrid>
-          {events.map((event) => (
-            <motion.div key={event.id || 'unknown'} variants={itemVariants}>
-              <EventCardItem
-                event={event}
-                isManager={isManager}
-                formatCompactDate={formatCompactDate}
-                formatTime={formatTime}
-                getEventCardDate={getEventCardDate}
-                getEventStatus={getEventStatus}
-                isRsvpd={isRsvpd}
-                handleEditEvent={handleEditEvent}
-                handleDeleteEventClick={handleDeleteEventClick}
-                handleRsvpClick={handleRsvpClick}
-              />
-            </motion.div>
-          ))}
+        {events.map((event) => {
+  const isOrganizer = event.organizers?.some(org => org.id === user.id);
+
+  return (
+    <motion.div key={event.id || 'unknown'} variants={itemVariants}>
+      <EventCardItem
+        event={{ ...event, isOrganizer }} 
+        isManager={isManager}
+        activeRole={activeRole}
+        formatCompactDate={formatCompactDate}
+        formatTime={formatTime}
+        getEventCardDate={getEventCardDate}
+        getEventStatus={getEventStatus}
+        isRsvpd={isRsvpd}
+        handleEditEvent={handleEditEvent}
+        handleDeleteEventClick={handleDeleteEventClick}
+        handleRsvpClick={handleRsvpClick}
+      />
+    </motion.div>
+  );
+})}
+
         </EventsGrid>
       </motion.div>
       

--- a/frontend/src/hooks/useEvents.js
+++ b/frontend/src/hooks/useEvents.js
@@ -183,7 +183,7 @@ export const useEvents = (params = {}) => {
     },
   });
   
-  // 定义基本返回值，所有用户都可使用
+ 
   const baseReturn = {
     events: data?.results || [],
     totalCount: data?.count || 0,
@@ -196,12 +196,12 @@ export const useEvents = (params = {}) => {
     isRsvping: rsvpToEventMutation.isPending,
     cancelRsvp: cancelRsvpMutation.mutate,
     isCancellingRsvp: cancelRsvpMutation.isPending,
-    // 添加updateEvent，所有用户都可以调用
+ 
     updateEvent: updateEventMutation.mutate,
     isUpdating: updateEventMutation.isPending,
   };
   
-  // 仅当用户是管理员时添加管理员特有功能
+ 
   if (isManager) {
     return {
       ...baseReturn,
@@ -222,7 +222,7 @@ export const useEvents = (params = {}) => {
     };
   }
   
-  // 非管理员也需要有添加/移除嘉宾功能（如果是组织者）
+
   return {
     ...baseReturn,
     addGuest: addGuestMutation.mutate,

--- a/frontend/src/pages/events/EventDetail.js
+++ b/frontend/src/pages/events/EventDetail.js
@@ -432,9 +432,14 @@ const AudienceName = styled.div`
 `;
 
 const AudienceRole = styled.div`
-  font-size: ${theme.typography.fontSize.xs};
-  color: ${theme.colors.text.secondary};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+  width: 60px; 
+  margin-top: -4px; 
 `;
+
 
 const EmptyAudienceSeat = styled.div`
   width: 60px;
@@ -1041,7 +1046,7 @@ const EventDetail = () => {
               </Card>
             )}
             
-            {activeTab === 'guests' && (
+            {activeTab === 'guests' && !(activeRole === 'regular' && !isU) && (
               <Card>
                 <Card.Header>
                   <Card.Title>Guests</Card.Title>
@@ -1112,32 +1117,33 @@ const EventDetail = () => {
                               </div>
 
                               <Tooltip id={`guest-tooltip-${guest.id}`} place="top" />
+                                                                <AudienceRole>
+                                    {guest.pointsAwarded ? (
+                                      <Badge color="success">{guest.pointsAwarded}pt</Badge>
+                                    ) : canEditEvent() && eventStatus.text === 'Upcoming' ? (
+                                      <ActionButton
+                                        size="tiny"
+                                        onClick={() => {
+                                          setSelectedUserId(guest.id);
+                                          setSelectedUtorid(guest.utorid);
+                                          setAwardPointsModalOpen(true);
+                                        }}
+                                      >
+                                        🏆
+                                      </ActionButton>
+                                    ) : <div />}
 
-                              <AudienceRole>
-                                {guest.pointsAwarded ? (
-                                  <Badge color="success">{guest.pointsAwarded}pt</Badge>
-                                ) : canEditEvent() && eventStatus.text === 'Upcoming' ? (
-                                  <ActionButton 
-                                    size="tiny" 
-                                    onClick={() => {
-                                      setSelectedUserId(guest.id);
-                                      setSelectedUtorid(guest.utorid);
-                                      setAwardPointsModalOpen(true);
-                                    }}
-                                  >
-                                    🏆
-                                  </ActionButton>
-                                ) : null}
-                                {canEditEvent() && (
-                                  <ActionButton 
-                                    size="tiny" 
-                                    color="error"
-                                    onClick={() => handleRemoveGuest(guest.id)}
-                                  >
-                                    ❌
-                                  </ActionButton>
-                                )}
-                              </AudienceRole>
+                                    {canEditEvent() ? (
+                                      <ActionButton
+                                        size="tiny"
+                                        color="error"
+                                        onClick={() => handleRemoveGuest(guest.id)}
+                                      >
+                                        ❌
+                                      </ActionButton>
+                                    ) : <div />}
+                                  </AudienceRole>
+
                             </AudienceSeat>
                           );
                         })}

--- a/frontend/src/pages/events/EventDetail.js
+++ b/frontend/src/pages/events/EventDetail.js
@@ -1046,7 +1046,7 @@ const EventDetail = () => {
               </Card>
             )}
             
-            {activeTab === 'guests' && !(activeRole === 'regular' && !isU) && (
+            {activeTab === 'guests' && !(activeRole === 'regular' && !isU) && activeRole !== 'cashier' && (
               <Card>
                 <Card.Header>
                   <Card.Title>Guests</Card.Title>


### PR DESCRIPTION
Hide the "points available" label on event cards if the current user is a regular user and not an organizer of the event. This improves information control by only showing point allocation data to users who are authorized to manage it.